### PR TITLE
Bench the spread operator vs apply()

### DIFF
--- a/benchmark/spread-operator.js
+++ b/benchmark/spread-operator.js
@@ -1,0 +1,13 @@
+'use strict'
+
+suite('spread operator', function () {
+  const noop = (a, b, c) => { };
+
+  bench('noop(...[1,2,3])', function () {
+    noop(...[1,2,3])
+  })
+
+  bench('noop.apply(null, [1,2,3])', function () {
+    noop.apply(null, [1,2,3])
+  })
+})


### PR DESCRIPTION
Benches the ... spread operator vs classic `.apply(context, args)` method.
(Only available in Node.js >= 5.x.x)
