### PR TITLE
Fix typo

### DIFF
--- a/benchmark/concat-strings.js
+++ b/benchmark/concat-strings.js
@@ -6,10 +6,10 @@ suite('template string vs use +', function () {
   let d = [4]
 
   bench('template string', function () {
-    let str = `a:${a} b:${b} c:${c} d:${d}`
+    return `a:${a} b:${b} c:${c} d:${d}`
   })
 
   bench("use +", function () {
-    let str = 'a:' + a + ' b:' + b + ' c:' + c + ' d:' + 'd'
+    return 'a:' + a + ' b:' + b + ' c:' + c + ' d:' + d
   })
 })


### PR DESCRIPTION
`'d' => d`, oops...

Note: Although Chrome & nodejs use the same JS engine, It seems that they have the different performance. Tested **concat-strings** on 3 different browsers. All of them runs faster with template string.
http://jsperf.com/template-string-vs-use-add-v2
